### PR TITLE
feat: search for path inside node_modules directory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Invisible Technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ machine:
     PORT: 3000
 
   node:
-    version: "8.1.2"
+    version: "8.1.4"
 
   timezone: America/Los_Angeles
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
   "name": "merge-parsers",
   "license": "UNLICENSED",
-<<<<<<< HEAD
-  "version": "1.0.1",
-=======
   "version": "1.1.0",
->>>>>>> f33a121... refactor: resolveDir, add test and fix version
   "description": "",
   "engines": {
     "node": "^8.1.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "merge-parsers",
   "license": "UNLICENSED",
+<<<<<<< HEAD
   "version": "1.0.1",
+=======
+  "version": "1.1.0",
+>>>>>>> f33a121... refactor: resolveDir, add test and fix version
   "description": "",
   "engines": {
     "node": "^8.1.4"
@@ -15,6 +19,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ignore-path .gitignore",
+    "postinstall": "scripts/postinstall.js",
     "pretest": "yarn run lint",
     "test": "mocha $(find test -name '*.spec.js')"
   },
@@ -38,6 +43,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.1.0",
     "glob": "^7.1.2",
-    "mocha": "^3.4.2"
+    "mocha": "^3.4.2",
+    "shelljs": "^0.7.8"
   }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const shell = require('shelljs')
+
+shell.echo('postinstall.js starting')
+
+if (! shell.test('-e', 'node_modules/~')) {
+  shell.echo('creating wavy symlink')
+  shell.ln('-sf', '../', 'node_modules/~')
+}
+
+shell.echo('postinstall.js done')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -17,6 +17,22 @@ describe('parsers', () => {
     assert.deepStrictEqual(actual, expected, 'it does not return the filenames as keys')
   })
 
+  it('should work with symlinks', () => {
+    const testPath = '~/test/parsers'
+
+    const parser = parsers({ path: testPath })
+
+    const actual = Object.keys(parser)
+    const expected = ['eol', 'whitespace']
+    assert.deepStrictEqual(actual, expected, 'it does not work with symlinks')
+  })
+
+  it('should throw with an invalid directory', () => {
+    const testPath = '~/test/passes'
+
+    assert.throws(() => parsers({ path: testPath }))
+  })
+
   it('should return a function', () => {
     const testPath = './test/parsers'
 
@@ -32,15 +48,7 @@ describe('parsers', () => {
 
     const parser = parsers({ graceful, path: testPath })
 
-    const parses = text => {
-      try {
-        return parser.whitespace(text)
-      } catch (e) {
-        return new Error(`This is a ${e.name} error`)
-      }
-    }
-    const actual = parses('2')
-    assert(actual instanceof Error, `should throw an error but is returning ${actual}`)
+    assert.throws(() => parser.whitespace('2'))
   })
 
   it('should return undefined when gracefulness is enabled', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,7 +490,7 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -597,6 +597,10 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -981,6 +985,12 @@ readable-stream@^2.2.2:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 req-all@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
@@ -996,7 +1006,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.2.0:
+resolve@^1.1.6, resolve@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
@@ -1048,6 +1058,14 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shelljs@^0.7.8:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This PR add a feature to `merge-parsers` module that allows the consumer to use a `path` (it can be a symbolic link) inside `node_modules` to his parsers directory.